### PR TITLE
Bf recursion

### DIFF
--- a/Tests/PuzzleGeneration/Program.cs
+++ b/Tests/PuzzleGeneration/Program.cs
@@ -4,23 +4,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-/*
- * On my laptop running 10x50:
-Timing the creation of 500 puzzles.
-50 puzzles created in 3.03 seconds for 17 puzzles per second.
-50 puzzles created in 3.03 seconds for 16 puzzles per second.
-50 puzzles created in 4.31 seconds for 12 puzzles per second.
-50 puzzles created in 5.49 seconds for 9 puzzles per second.
-50 puzzles created in 5.10 seconds for 10 puzzles per second.
-50 puzzles created in 5.56 seconds for 9 puzzles per second.
-50 puzzles created in 7.40 seconds for 7 puzzles per second.
-50 puzzles created in 4.92 seconds for 10 puzzles per second.
-50 puzzles created in 7.64 seconds for 7 puzzles per second.
-50 puzzles created in 4.78 seconds for 10 puzzles per second.
-500 puzzles created in 51.26 seconds for 10 puzzles per second.
-Press any key to continue . . .
-*/
-
 namespace PuzzleGeneration
 {
     class Program

--- a/src/Board/Board_Properties.cs
+++ b/src/Board/Board_Properties.cs
@@ -166,16 +166,27 @@ namespace SudokuSharp
             if (IsSolved) return true;
             if (!IsValid) return false;
 
+            var work = new Board(this);
+
+            var c = work.Find.AllSingles();
+            while (c.Count() > 0)
+            {
+                foreach (var single in c)
+                    work[single.Key] = single.Value;
+
+                c = work.Find.AllSingles();
+            }
+
             foreach (var idx in Location.All)
             {
-                if (data[idx] == 0)
+                if (work.data[idx] == 0)
                 { // Only test against empty cells
-                    var Candidates = Find.Candidates(idx);
+                    var Candidates = work.Find.Candidates(idx);
 
                     if (Candidates.Count > 1)
                     { // Only test where there's more than one option
                         bool foundSolution = false;
-                        var working = new Board(this);
+                        var working = new Board(work);
 
                         foreach (int test in Candidates)
                         {

--- a/src/Board/Fill/Fill.cs
+++ b/src/Board/Fill/Fill.cs
@@ -37,7 +37,7 @@ namespace SudokuSharp
                 _parent = Parent;
             }
 
-            // This class is not made public because it only checks for the presence of a digit in a row or column.
+            // This class is not made public because it only checks for the presence of a digit in a row or column or zone.
             // It does nothing to guard against duplicates, so is useless for the general board class.
             class ConstraintData
             {


### PR DESCRIPTION
Fills in hidden and naked singles in a board before performing brute force recursion, resulting in a 50% speed increase.